### PR TITLE
Add Cheminformatics and Metabolomics as BiocViews

### DIFF
--- a/BridgeDbR/DESCRIPTION
+++ b/BridgeDbR/DESCRIPTION
@@ -10,7 +10,7 @@ Depends: R (>= 3.2.0), rJava
 Imports: RCurl
 Suggests: testthat
 Description: Use BridgeDb functions and load identifier mapping databases in R.
-biocViews: Software, Annotation
+biocViews: Software, Annotation, Metabolomics, Cheminformatics
 License: AGPL-3
 LazyLoad: yes
 URL: https://github.com/bridgedb/BridgeDb, https://github.com/BiGCAT-UM/bridgedb-r


### PR DESCRIPTION
That way they will show up in http://bioconductor.org/packages/release/BiocViews.html#___Metabolomics
and also in the auto-created docker containers https://hub.docker.com/r/bioconductor/devel_metabolomics2/